### PR TITLE
allow svirt_lxc_net_t kernel_t:fifo_file write

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -457,3 +457,4 @@ mcs_process_set_categories(kernel_t)
 mcs_ptrace_all(kernel_t)
 
 allow kernel_t unconfined_t:process { transition dyntransition };
+allow svirt_lxc_net_t kernel_t:fifo_file write;


### PR DESCRIPTION
on rancher os, If selinux is enable, “docker run ubuntu ls" will has no output, this will affect CI test .
from audit info, we can see :

```
[  519.379439] audit: type=1400 audit(1466752574.123:5): avc:  denied  { read } for  pid=1845 comm="ls" path="pipe:[26373]" dev="pipefs" ino=26373 scontext=system_u:system_r:svirt_lxc_net_t:s0:c715,c884 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=0
[  519.382250] audit: type=1400 audit(1466752574.126:6): avc:  denied  { write } for  pid=1845 comm="ls" path="pipe:[26374]" dev="pipefs" ino=26374 scontext=system_u:system_r:svirt_lxc_net_t:s0:c715,c884 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=0
[  519.384935] audit: type=1400 audit(1466752574.128:7): avc:  denied  { write } for  pid=1845 comm="ls" path="pipe:[26375]" dev="pipefs" ino=26375 scontext=system_u:system_r:svirt_lxc_net_t:s0:c715,c884 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=0
```

this pr can resolve it.

@joshwget WDYT ?

Signed-off-by: Shukui Yang yangshukui@huawei.com
